### PR TITLE
Fix README license to MIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ cat tickets.yaml
 
 ## License
 
-This project is licensed under the GNU Affero General Public License v3.0 (MIT). See [LICENSE](LICENSE) for details.
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
 
 ---
 


### PR DESCRIPTION
README incorrectly stated GNU Affero General Public License v3.0. Updated to MIT to match the LICENSE file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated license information to MIT.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/privkeyio/hydra/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->