### PR TITLE
Add NEAR AI Cloud provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # Copy this file to .env and fill in your values
 
 # LLM Provider Selection
-# Options: claude_tmux, venice, anthropic, openai, claude_cli
+# Options: claude_tmux, nearai, venice, anthropic, openai, claude_cli
 # Default: claude_tmux (if Claude CLI is available)
 # LLM_PROVIDER=claude_tmux
 
@@ -15,6 +15,10 @@
 # Venice AI (great for rapid development)
 VENICE_API_KEY=your_venice_api_key_here
 # VENICE_BASE_URL=https://api.venice.ai/api/v1  # Optional custom endpoint
+
+# NEAR AI Cloud TEE inference
+# NEARAI_API_KEY=your_nearai_api_key_here
+# NEARAI_BASE_URL=https://cloud-api.near.ai/v1  # Optional custom endpoint
 
 # Anthropic Claude
 # ANTHROPIC_API_KEY=your_anthropic_api_key_here

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pip install -e .
 ### Basic Setup
 
 ```bash
-# Choose your LLM provider (claude_tmux, nearai, venice, mock)
+# Choose your LLM provider (claude_tmux, nearai, venice, anthropic, openai, claude_cli, mock)
 export LLM_PROVIDER=nearai  # or claude_tmux
 
 # For Claude provider

--- a/README.md
+++ b/README.md
@@ -65,13 +65,16 @@ pip install -e .
 ### Basic Setup
 
 ```bash
-# Choose your LLM provider (claude_tmux, venice, mock)
-export LLM_PROVIDER=venice  # or claude_tmux
+# Choose your LLM provider (claude_tmux, nearai, venice, mock)
+export LLM_PROVIDER=nearai  # or claude_tmux
 
 # For Claude provider
 export CLAUDE_CLI_PATH=/path/to/claude
 # OR
 export ANTHROPIC_API_KEY=your_key
+
+# For NEAR AI Cloud TEE inference
+export NEARAI_API_KEY=your_key  # Get from https://cloud.near.ai
 
 # For Venice provider (recommended for open-source models)
 export VENICE_API_KEY=your_key  # Get from https://venice.ai
@@ -186,6 +189,7 @@ hydra dashboard stop   # Stop the dashboard
 ## Provider Support
 
 - **Claude** (claude_tmux) - Interactive Claude Code CLI via tmux
+- **NEAR AI Cloud** (nearai) - OpenAI-compatible TEE inference
 - **Venice AI** (venice) - Production-ready with retry logic and streaming
 - **Anthropic** (anthropic) - Direct API integration
 - **OpenAI** (openai) - GPT-4 and GPT-3.5 support

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -2,7 +2,7 @@
 
 # LLM Provider Configuration
 llm:
-  # Provider type: venice, anthropic, openai, claude_cli
+  # Provider type: nearai, venice, anthropic, openai, claude_cli
   provider: claude_cli
   
   # Model name (optional - uses provider default if not specified)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       VENICE_API_KEY: ${VENICE_API_KEY}
       NEARAI_API_KEY: ${NEARAI_API_KEY}
+      NEARAI_BASE_URL: ${NEARAI_BASE_URL}
       API_KEYS: ${API_KEYS:-hydra_test_key}
       RATE_LIMIT_REQUESTS: ${RATE_LIMIT_REQUESTS:-100}
       RATE_LIMIT_WINDOW: ${RATE_LIMIT_WINDOW:-3600}
@@ -79,6 +80,7 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       VENICE_API_KEY: ${VENICE_API_KEY}
       NEARAI_API_KEY: ${NEARAI_API_KEY}
+      NEARAI_BASE_URL: ${NEARAI_BASE_URL}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       VENICE_API_KEY: ${VENICE_API_KEY}
+      NEARAI_API_KEY: ${NEARAI_API_KEY}
       API_KEYS: ${API_KEYS:-hydra_test_key}
       RATE_LIMIT_REQUESTS: ${RATE_LIMIT_REQUESTS:-100}
       RATE_LIMIT_WINDOW: ${RATE_LIMIT_WINDOW:-3600}
@@ -77,6 +78,7 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       VENICE_API_KEY: ${VENICE_API_KEY}
+      NEARAI_API_KEY: ${NEARAI_API_KEY}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -310,6 +310,15 @@ Venice AI provider using OpenAI-compatible API.
 - `base_url`: API endpoint (default: https://api.venice.ai/api/v1)
 - `model`: Model to use (default: qwen-2.5-coder-32b)
 
+#### NearAIProvider
+
+NEAR AI Cloud provider using OpenAI-compatible TEE inference.
+
+**Configuration:**
+- `api_key`: Required NEAR AI Cloud API key
+- `base_url`: API endpoint (default: https://cloud-api.near.ai/v1)
+- `model`: Model to use (default: zai-org/GLM-5.1-FP8)
+
 #### AnthropicProvider
 
 Anthropic Claude provider.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -149,6 +149,7 @@ LLMProvider (Abstract Base)
 │   ├── generate_json(prompt) -> Dict
 │   └── list_models() -> List[str]
 └── Implementations
+    ├── NearAIProvider
     ├── VeniceProvider
     ├── AnthropicProvider
     ├── OpenAIProvider
@@ -162,6 +163,7 @@ providers/
 ├── __init__.py      # Imports all providers
 ├── base.py          # Abstract base class
 ├── factory.py       # Factory with registry
+├── nearai.py        # NEAR AI Cloud implementation
 ├── venice.py        # Venice implementation
 ├── anthropic.py     # Anthropic implementation
 ├── openai.py        # OpenAI implementation
@@ -263,7 +265,8 @@ subprocess.run(
 ### API Key Management
 ```
 .env (git-ignored)
-├── LLM_PROVIDER (venice|anthropic|openai|claude_cli)
+├── LLM_PROVIDER (nearai|venice|anthropic|openai|claude_cli)
+├── NEARAI_API_KEY
 ├── VENICE_API_KEY
 ├── ANTHROPIC_API_KEY
 ├── OPENAI_API_KEY

--- a/docs/NEARAI_SETUP.md
+++ b/docs/NEARAI_SETUP.md
@@ -1,0 +1,84 @@
+# NEAR AI Cloud Provider Setup Guide
+
+NEAR AI Cloud provides OpenAI-compatible TEE inference through
+`https://cloud-api.near.ai/v1`.
+
+## Quick Start
+
+### 1. Get Your API Key
+
+Create an API key from the NEAR AI Cloud dashboard at `https://cloud.near.ai`.
+
+### 2. Configure Hydra
+
+```bash
+export LLM_PROVIDER=nearai
+export NEARAI_API_KEY=your_api_key_here
+```
+
+Optional overrides:
+
+```bash
+export NEARAI_BASE_URL=https://cloud-api.near.ai/v1
+export LLM_MODEL=zai-org/GLM-5.1-FP8
+```
+
+### 3. Test Initialization
+
+```bash
+python -c "
+from hydra.providers.nearai import NearAIProvider
+from hydra.providers.base import LLMConfig
+import os
+
+config = LLMConfig(
+    provider_type='nearai',
+    api_key=os.getenv('NEARAI_API_KEY'),
+)
+provider = NearAIProvider(config)
+print(provider.name, provider.config.base_url, provider.config.model)
+"
+```
+
+## Default Models
+
+Hydra maps generic model names to TEE-backed NEAR AI Cloud chat models:
+
+| Generic name | NEAR AI Cloud model |
+|--------------|---------------------|
+| `fast` | `Qwen/Qwen3.6-35B-A3B-FP8` |
+| `balanced` | `zai-org/GLM-5.1-FP8` |
+| `smart` | `Qwen/Qwen3.5-122B-A10B` |
+| `coder` | `zai-org/GLM-5.1-FP8` |
+| `vision` | `Qwen/Qwen3-VL-30B-A3B-Instruct` |
+
+The static list was generated from the public model catalog endpoint:
+
+```bash
+curl https://cloud-api.near.ai/v1/model/list
+```
+
+## Programmatic Usage
+
+```python
+from hydra.providers.base import LLMConfig
+from hydra.providers.nearai import NearAIProvider
+
+config = LLMConfig(
+    provider_type="nearai",
+    model="zai-org/GLM-5.1-FP8",
+    api_key="your_api_key",
+    base_url="https://cloud-api.near.ai/v1",
+    temperature=0.3,
+    max_tokens=3000,
+)
+
+provider = NearAIProvider(config)
+response = provider.generate("Create a Python data validation module")
+```
+
+## Troubleshooting
+
+If authentication fails, confirm `NEARAI_API_KEY` is set in the same shell that
+runs Hydra. If a model is unavailable, fetch the current catalog and set
+`LLM_MODEL` to one of the returned `modelId` values.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,15 +12,17 @@ Multi-agent orchestration system with pluggable LLM provider support.
 ### Provider System
 - **[Provider Configuration](providers/configuration.md)** - Setup LLM providers
 - **[Provider Implementation](providers/implementation.md)** - Create custom providers
+- **[NEAR AI Cloud Setup](NEARAI_SETUP.md)** - Configure NEAR AI Cloud TEE inference
 
 ## 🚀 Quick Start
 
 ```bash
-# Set your provider (claude_tmux, venice, mock)
+# Set your provider (claude_tmux, nearai, venice, mock)
 export LLM_PROVIDER=claude_tmux
 
 # Configure provider credentials
 export CLAUDE_CLI_PATH=/path/to/claude  # For Claude
+export NEARAI_API_KEY=your_key         # For NEAR AI Cloud
 export VENICE_API_KEY=your_key         # For Venice
 
 # Run a task
@@ -36,6 +38,7 @@ hydra ticket parallel --workers 4
 | Provider | Type | Description |
 |----------|------|-------------|
 | `claude_tmux` | Interactive | Claude Code CLI via tmux sessions |
+| `nearai` | API | NEAR AI Cloud TEE inference |
 | `venice` | API | Venice.ai API integration |
 | `mock` | Testing | Development and testing provider |
 

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -333,6 +333,11 @@ Available Providers:
     Status: ✓ Configured
     Models: llama-3.1-8b, llama-3.1-70b, llama-3.1-405b
     Features: streaming, parallel
+
+  nearai
+    Status: ✓ Configured
+    Models: Qwen/Qwen3.6-35B-A3B-FP8, zai-org/GLM-5.1-FP8
+    Features: streaming, parallel, tee-inference
     
   mock
     Status: ✓ Available
@@ -360,6 +365,7 @@ hydra provider test [options] [provider-name]
 hydra provider test
 
 # Test specific provider
+hydra provider test nearai
 hydra provider test venice
 
 # Full test with benchmarks
@@ -653,10 +659,11 @@ Configure Hydra through environment variables:
 
 ```bash
 # Provider selection
-export LLM_PROVIDER=venice
-export LLM_MODEL=llama-3.1-70b
+export LLM_PROVIDER=nearai
+export LLM_MODEL=zai-org/GLM-5.1-FP8
 
 # Provider-specific
+export NEARAI_API_KEY=your_key
 export VENICE_API_KEY=your_key
 export CLAUDE_CLI_PATH=/usr/local/bin/claude
 
@@ -677,8 +684,8 @@ Create `.hydra.yaml` in your project:
 
 ```yaml
 # .hydra.yaml
-provider: venice
-model: llama-3.1-70b
+provider: nearai
+model: zai-org/GLM-5.1-FP8
 context:
   - src/
   - tests/
@@ -696,6 +703,8 @@ default_provider: claude
 providers:
   claude:
     default_model: opus
+  nearai:
+    default_model: zai-org/GLM-5.1-FP8
   venice:
     default_model: llama-3.1-70b
     

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,8 +21,8 @@ pip install git+https://github.com/privkeyio/hydra.git
 export LLM_PROVIDER=mock
 
 # For real projects
-export LLM_PROVIDER=venice
-export VENICE_API_KEY=your_key  # Get from venice.ai
+export LLM_PROVIDER=nearai
+export NEARAI_API_KEY=your_key  # Get from cloud.near.ai
 ```
 
 ### 2. Create Tickets
@@ -99,7 +99,14 @@ export LLM_PROVIDER=mock
 ```
 No API needed, returns sample responses.
 
-### Venice (Recommended)
+### NEAR AI Cloud
+```bash
+export LLM_PROVIDER=nearai
+export NEARAI_API_KEY=your_key
+```
+OpenAI-compatible TEE inference through NEAR AI Cloud.
+
+### Venice
 ```bash
 export LLM_PROVIDER=venice
 export VENICE_API_KEY=your_key

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -16,6 +16,12 @@ export LLM_PROVIDER=venice
 export VENICE_API_KEY=your_key
 ```
 
+### NEAR AI Cloud Provider
+```bash
+export LLM_PROVIDER=nearai
+export NEARAI_API_KEY=your_key
+```
+
 ### Mock Provider (Testing)
 ```bash
 export LLM_PROVIDER=mock

--- a/docs/providers/configuration.md
+++ b/docs/providers/configuration.md
@@ -9,6 +9,7 @@ Hydra supports multiple LLM providers through a flexible provider abstraction la
 Hydra currently supports the following providers:
 
 - **Claude (Tmux)** - Interactive Claude Code CLI sessions via tmux
+- **NEAR AI Cloud** - OpenAI-compatible TEE inference
 - **Venice AI** - API-based access to various open-source models
 - **Mock Provider** - For testing and development
 
@@ -20,10 +21,11 @@ The simplest way to configure a provider is through environment variables:
 
 ```bash
 # Select the provider
-export LLM_PROVIDER=claude_tmux  # Options: claude_tmux, venice, mock
+export LLM_PROVIDER=claude_tmux  # Options: claude_tmux, nearai, venice, mock
 
 # Provider-specific configuration
 export CLAUDE_CLI_PATH=/path/to/claude  # For Claude provider
+export NEARAI_API_KEY=your_api_key      # For NEAR AI Cloud provider
 export VENICE_API_KEY=your_api_key      # For Venice provider
 
 # Optional settings
@@ -68,6 +70,20 @@ providers:
       fast: llama-3.1-8b
       balanced: llama-3.1-70b
       smart: llama-3.1-405b
+    features:
+      interactive: false
+      streaming: true
+      file_safety: false
+
+  nearai:
+    type: nearai
+    api_key: ${NEARAI_API_KEY}
+    base_url: https://cloud-api.near.ai/v1
+    default_model: zai-org/GLM-5.1-FP8
+    models:
+      fast: Qwen/Qwen3.6-35B-A3B-FP8
+      balanced: zai-org/GLM-5.1-FP8
+      smart: Qwen/Qwen3.5-122B-A10B
     features:
       interactive: false
       streaming: true
@@ -185,6 +201,34 @@ export LLM_MODEL=llama-3.1-70b
 hydra test-provider
 ```
 
+### NEAR AI Cloud Provider
+
+The NEAR AI Cloud provider connects to NEAR AI's OpenAI-compatible Cloud API
+and defaults to TEE-backed model entries from the public model catalog.
+
+#### Requirements
+
+- NEAR AI Cloud API key
+- Internet connection
+
+#### Configuration Options
+
+| Option | Environment Variable | Description | Default |
+|--------|---------------------|-------------|---------|
+| api_key | NEARAI_API_KEY | NEAR AI Cloud API key | Required |
+| base_url | NEARAI_BASE_URL | API endpoint URL | `https://cloud-api.near.ai/v1` |
+| model | LLM_MODEL | Model identifier | `zai-org/GLM-5.1-FP8` |
+| timeout | LLM_TIMEOUT | Request timeout | `300` |
+| max_retries | LLM_MAX_RETRIES | Retry attempts | `3` |
+
+#### Example Setup
+
+```bash
+export NEARAI_API_KEY=your_key
+export LLM_PROVIDER=nearai
+export LLM_MODEL=zai-org/GLM-5.1-FP8
+```
+
 ### Mock Provider
 
 The mock provider is useful for testing and development without consuming API credits.
@@ -217,14 +261,17 @@ Hydra uses a model mapping system to translate generic model identifiers to prov
 model_mappings:
   fast:
     claude: haiku
+    nearai: Qwen/Qwen3.6-35B-A3B-FP8
     venice: llama-3.1-8b
     
   balanced:
     claude: sonnet
+    nearai: zai-org/GLM-5.1-FP8
     venice: llama-3.1-70b
     
   smart:
     claude: opus
+    nearai: Qwen/Qwen3.5-122B-A10B
     venice: llama-3.1-405b
 ```
 
@@ -247,15 +294,15 @@ hydra generate --model sonnet "Create a web server"
 
 Not all providers support all features. Here's a compatibility matrix:
 
-| Feature | Claude | Venice | Mock |
-|---------|--------|--------|------|
-| Interactive Mode | ✓ | ✗ | ✗ |
-| Streaming Output | ✓ | ✓ | ✗ |
-| Session Persistence | ✓ | ✗ | ✗ |
-| File Safety Checks | ✓ | ✗ | ✓ |
-| Parallel Execution | ✓ | ✓ | ✓ |
-| Code Extraction | ✓ | ✓ | ✓ |
-| Custom Prompts | ✓ | ✓ | ✓ |
+| Feature | Claude | NEAR AI Cloud | Venice | Mock |
+|---------|--------|---------------|--------|------|
+| Interactive Mode | ✓ | ✗ | ✗ | ✗ |
+| Streaming Output | ✓ | ✓ | ✓ | ✗ |
+| Session Persistence | ✓ | ✗ | ✗ | ✗ |
+| File Safety Checks | ✓ | ✗ | ✗ | ✓ |
+| Parallel Execution | ✓ | ✓ | ✓ | ✓ |
+| Code Extraction | ✓ | ✓ | ✓ | ✓ |
+| Custom Prompts | ✓ | ✓ | ✓ | ✓ |
 
 ## Fallback Configuration
 

--- a/docs/providers/configuration.md
+++ b/docs/providers/configuration.md
@@ -21,7 +21,7 @@ The simplest way to configure a provider is through environment variables:
 
 ```bash
 # Select the provider
-export LLM_PROVIDER=claude_tmux  # Options: claude_tmux, nearai, venice, mock
+export LLM_PROVIDER=claude_tmux  # Options: claude_tmux, nearai, venice, anthropic, openai, claude_cli, mock
 
 # Provider-specific configuration
 export CLAUDE_CLI_PATH=/path/to/claude  # For Claude provider
@@ -491,4 +491,4 @@ See the [Migration Guide](migration.md) for detailed instructions.
 - [Provider Implementation Guide](implementation.md) - Create custom providers
 - [Venice Setup Guide](venice-setup.md) - Detailed Venice configuration
 - [CLI Commands](../cli-commands.md) - Using providers with CLI
-- [API Reference](../api/providers.md) - Provider API documentation
+- [API Reference](../API_REFERENCE.md) - Provider API documentation

--- a/src/hydra/cli/main.py
+++ b/src/hydra/cli/main.py
@@ -130,7 +130,15 @@ def create_parser() -> argparse.ArgumentParser:
     # Global provider override flags
     parser.add_argument(
         "--provider",
-        choices=["venice", "claude_tmux", "claude_code", "anthropic", "openai", "mock"],
+        choices=[
+            "nearai",
+            "venice",
+            "claude_tmux",
+            "claude_code",
+            "anthropic",
+            "openai",
+            "mock",
+        ],
         help="Override the LLM provider (default: from env or config)"
     )
     parser.add_argument(
@@ -301,4 +309,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/src/hydra/config.py
+++ b/src/hydra/config.py
@@ -118,6 +118,12 @@ class HydraConfig:
                 'VENICE_BASE_URL', 'https://api.venice.ai/api/v1'
             )
 
+        elif provider_type in ['nearai', 'nearai_api']:
+            config.api_key = os.getenv('NEARAI_API_KEY')
+            config.base_url = os.getenv(
+                'NEARAI_BASE_URL', 'https://cloud-api.near.ai/v1'
+            )
+
         elif provider_type == 'anthropic':
             config.api_key = os.getenv('ANTHROPIC_API_KEY')
 

--- a/src/hydra/performance.py
+++ b/src/hydra/performance.py
@@ -155,6 +155,10 @@ class RequestBatcher:
                 "x-api-key": os.getenv("ANTHROPIC_API_KEY"),
                 "anthropic-version": "2023-06-01"
             }
+        elif provider in ["nearai", "nearai_api"]:
+            base_url = os.getenv("NEARAI_BASE_URL", "https://cloud-api.near.ai/v1")
+            url = base_url + "/chat/completions"
+            headers = {"Authorization": f"Bearer {os.getenv('NEARAI_API_KEY')}"}
         else:
             base_url = os.getenv("VENICE_BASE_URL", "https://api.venice.ai/api/v1")
             url = base_url + "/chat/completions"
@@ -218,6 +222,14 @@ class StreamingResponseHandler:
                 headers = {
                     "x-api-key": os.getenv("ANTHROPIC_API_KEY"),
                     "anthropic-version": "2023-06-01"
+                }
+            elif provider in ["nearai", "nearai_api"]:
+                base_url = os.getenv(
+                    "NEARAI_BASE_URL", "https://cloud-api.near.ai/v1"
+                )
+                url = base_url + "/chat/completions"
+                headers = {
+                    "Authorization": f"Bearer {os.getenv('NEARAI_API_KEY')}"
                 }
             else:
                 base_url = os.getenv("VENICE_BASE_URL", "https://api.venice.ai/api/v1")
@@ -319,4 +331,3 @@ async def initialize_performance_optimizations():
 
 async def cleanup_performance_resources():
     await pool_manager.close_all()
-

--- a/src/hydra/performance_optimizations.py
+++ b/src/hydra/performance_optimizations.py
@@ -268,7 +268,15 @@ class LLMRequestBatcher:
             "venice": (
                 os.getenv("VENICE_BASE_URL", "https://api.venice.ai/api/v1")
                 + "/chat/completions"
-            )
+            ),
+            "nearai": (
+                os.getenv("NEARAI_BASE_URL", "https://cloud-api.near.ai/v1")
+                + "/chat/completions"
+            ),
+            "nearai_api": (
+                os.getenv("NEARAI_BASE_URL", "https://cloud-api.near.ai/v1")
+                + "/chat/completions"
+            ),
         }
 
         headers = self._get_headers(provider)
@@ -286,6 +294,8 @@ class LLMRequestBatcher:
                 "x-api-key": os.getenv("ANTHROPIC_API_KEY"),
                 "anthropic-version": "2023-06-01"
             }
+        elif provider in ["nearai", "nearai_api"]:
+            return {"Authorization": f"Bearer {os.getenv('NEARAI_API_KEY')}"}
         else:  # venice or default
             return {"Authorization": f"Bearer {os.getenv('VENICE_API_KEY')}"}
 

--- a/src/hydra/providers/__init__.py
+++ b/src/hydra/providers/__init__.py
@@ -33,6 +33,13 @@ except ImportError:
     VeniceProvider = None
     _VENICE_AVAILABLE = False
 
+try:
+    from .nearai import NearAIProvider
+    _NEARAI_AVAILABLE = True
+except ImportError:
+    NearAIProvider = None
+    _NEARAI_AVAILABLE = False
+
 # Create global factory instance
 provider_factory = LLMProviderFactory()
 
@@ -48,6 +55,8 @@ __all__ = [
 # Add optional providers to __all__ if available
 if _VENICE_AVAILABLE:
     __all__.append('VeniceProvider')
+if _NEARAI_AVAILABLE:
+    __all__.append('NearAIProvider')
 if _ANTHROPIC_AVAILABLE:
     __all__.append('AnthropicProvider')
 if _OPENAI_AVAILABLE:

--- a/src/hydra/providers/factory.py
+++ b/src/hydra/providers/factory.py
@@ -61,6 +61,8 @@ def auto_register_providers():
         'venice': 'VeniceProvider',
         'anthropic': 'AnthropicProvider',
         'openai': 'OpenAIProvider',
+        'nearai': 'NearAIProvider',
+        'nearai_api': 'NearAIProvider',
         'mock': 'MockProvider',
         'mock_provider': 'MockProvider',  # Alias for compatibility
         'claude_session': 'ClaudeSessionProvider',
@@ -94,7 +96,15 @@ class LLMProviderFactory:
 
     def __init__(self):
         # Auto-register core providers on first use
-        if not any(p in ProviderRegistry._providers for p in ['venice', 'anthropic', 'openai', 'mock', 'claude_session']):
+        core_providers = [
+            'venice',
+            'nearai',
+            'anthropic',
+            'openai',
+            'mock',
+            'claude_session',
+        ]
+        if not any(p in ProviderRegistry._providers for p in core_providers):
             auto_register_providers()
 
     def create(self, config: LLMConfig) -> LLMProvider:

--- a/src/hydra/providers/nearai.py
+++ b/src/hydra/providers/nearai.py
@@ -1,0 +1,128 @@
+"""NEAR AI Cloud provider implementation."""
+
+from hydra.providers.venice import VeniceProvider
+
+
+class NearAIProvider(VeniceProvider):
+    """NEAR AI Cloud TEE inference provider using the OpenAI-compatible API."""
+
+    PROVIDER_TYPE = "nearai"
+    PROVIDER_SLUG = "nearai"
+    DISPLAY_NAME = "NEAR AI Cloud"
+    API_KEY_ENV_VAR = "NEARAI_API_KEY"
+    DEFAULT_BASE_URL = "https://cloud-api.near.ai/v1"
+    DEFAULT_MODEL = "zai-org/GLM-5.1-FP8"
+
+    # Static chat model snapshot generated from:
+    # GET https://cloud-api.near.ai/v1/model/list on 2026-05-21.
+    MODEL_CATALOG = {
+        "Qwen/Qwen3.6-35B-A3B-FP8": {
+            "display_name": "Qwen 3.6 35B A3B FP8",
+            "category": "fast",
+            "context_window": 262144,
+            "max_output_tokens": 4096,
+            "supports_streaming": True,
+            "supports_interactive": False,
+            "cost_per_token": 0.00000017,
+            "metadata": {
+                "tee_inference": True,
+                "verifiable": True,
+                "attestation_supported": True,
+            },
+        },
+        "zai-org/GLM-5.1-FP8": {
+            "display_name": "GLM 5.1",
+            "category": "balanced",
+            "context_window": 202752,
+            "max_output_tokens": 4096,
+            "supports_streaming": True,
+            "supports_interactive": False,
+            "cost_per_token": 0.00000085,
+            "metadata": {
+                "tee_inference": True,
+                "verifiable": True,
+                "attestation_supported": True,
+            },
+        },
+        "Qwen/Qwen3.5-122B-A10B": {
+            "display_name": "Qwen3.5 122B A10B",
+            "category": "smart",
+            "context_window": 131072,
+            "max_output_tokens": 4096,
+            "supports_streaming": True,
+            "supports_interactive": False,
+            "cost_per_token": 0.0000004,
+            "metadata": {
+                "tee_inference": True,
+                "verifiable": True,
+                "attestation_supported": True,
+            },
+        },
+        "Qwen/Qwen3-30B-A3B-Instruct-2507": {
+            "display_name": "Qwen3 30B A3B Instruct 2507",
+            "category": "balanced",
+            "context_window": 262144,
+            "max_output_tokens": 4096,
+            "supports_streaming": True,
+            "supports_interactive": False,
+            "cost_per_token": 0.00000015,
+            "metadata": {
+                "tee_inference": True,
+                "verifiable": True,
+                "attestation_supported": True,
+            },
+        },
+        "openai/gpt-oss-120b": {
+            "display_name": "GPT OSS 120B",
+            "category": "smart",
+            "context_window": 131000,
+            "max_output_tokens": 4096,
+            "supports_streaming": True,
+            "supports_interactive": False,
+            "cost_per_token": 0.00000015,
+            "metadata": {
+                "tee_inference": True,
+                "verifiable": True,
+                "attestation_supported": True,
+            },
+        },
+        "google/gemma-4-31B-it": {
+            "display_name": "Gemma 4 31B Instruct",
+            "category": "fast",
+            "context_window": 262144,
+            "max_output_tokens": 4096,
+            "supports_streaming": True,
+            "supports_interactive": False,
+            "cost_per_token": 0.00000013,
+            "metadata": {
+                "tee_inference": True,
+                "verifiable": True,
+                "attestation_supported": True,
+            },
+        },
+        "Qwen/Qwen3-VL-30B-A3B-Instruct": {
+            "display_name": "Qwen3 VL 30B A3B Instruct",
+            "category": "balanced",
+            "context_window": 256000,
+            "max_output_tokens": 4096,
+            "supports_streaming": True,
+            "supports_interactive": False,
+            "cost_per_token": 0.00000015,
+            "metadata": {
+                "tee_inference": True,
+                "verifiable": True,
+                "attestation_supported": True,
+                "vision": True,
+            },
+        },
+    }
+
+    MODEL_MAPPINGS = {
+        "fast": "Qwen/Qwen3.6-35B-A3B-FP8",
+        "balanced": "zai-org/GLM-5.1-FP8",
+        "smart": "Qwen/Qwen3.5-122B-A10B",
+        "coder": "zai-org/GLM-5.1-FP8",
+        "vision": "Qwen/Qwen3-VL-30B-A3B-Instruct",
+        "opus": "zai-org/GLM-5.1-FP8",
+        "sonnet": "Qwen/Qwen3.6-35B-A3B-FP8",
+    }

--- a/src/hydra/providers/output_handler.py
+++ b/src/hydra/providers/output_handler.py
@@ -548,9 +548,9 @@ class ClaudeOutputHandler(OutputHandler):
 class VeniceOutputHandler(OutputHandler):
     """Output handler for Venice AI text responses."""
 
-    def __init__(self):
+    def __init__(self, provider_name: str = "venice"):
         """Initialize Venice output handler."""
-        super().__init__("venice")
+        super().__init__(provider_name)
 
     def parse(self, response: str) -> ParsedResponse:
         """Parse Venice response.
@@ -569,7 +569,7 @@ class VeniceOutputHandler(OutputHandler):
             text=response,
             code_blocks=code_blocks,
             metadata={
-                "provider": "venice",
+                "provider": self.provider_name,
                 "requires_code_extraction": True
             }
         )
@@ -594,7 +594,7 @@ class VeniceOutputHandler(OutputHandler):
             text_sections=text_sections,
             commands=commands,
             files=files,
-            metadata={"provider": "venice", "model": "varies"}
+            metadata={"provider": self.provider_name, "model": "varies"}
         )
 
     def _extract_venice_code(self, response: str) -> List[CodeBlock]:
@@ -829,6 +829,7 @@ class OutputHandlerFactory:
         "claude": ClaudeOutputHandler,
         "claude_tmux": ClaudeOutputHandler,
         "venice": VeniceOutputHandler,
+        "nearai": VeniceOutputHandler,
     }
 
     @classmethod

--- a/src/hydra/providers/provider_config.py
+++ b/src/hydra/providers/provider_config.py
@@ -156,7 +156,7 @@ class ProviderConfigManager:
             }
         },
         "nearai": {
-            "type": "nearai",
+            "type": "nearai_api",
             "enabled": True,
             "api_key": "${NEARAI_API_KEY}",
             "base_url": "https://cloud-api.near.ai/v1",

--- a/src/hydra/providers/provider_config.py
+++ b/src/hydra/providers/provider_config.py
@@ -155,6 +155,75 @@ class ProviderConfigManager:
                 "context_extension": False
             }
         },
+        "nearai": {
+            "type": "nearai",
+            "enabled": True,
+            "api_key": "${NEARAI_API_KEY}",
+            "base_url": "https://cloud-api.near.ai/v1",
+            "default_model": "zai-org/GLM-5.1-FP8",
+            "models": {
+                "fast": {
+                    "provider_identifier": "Qwen/Qwen3.6-35B-A3B-FP8",
+                    "category": "fast",
+                    "context_window": 262144,
+                    "max_output_tokens": 4096,
+                    "cost_per_million_tokens": 0.17
+                },
+                "balanced": {
+                    "provider_identifier": "zai-org/GLM-5.1-FP8",
+                    "category": "balanced",
+                    "context_window": 202752,
+                    "max_output_tokens": 4096,
+                    "cost_per_million_tokens": 0.85
+                },
+                "smart": {
+                    "provider_identifier": "Qwen/Qwen3.5-122B-A10B",
+                    "category": "smart",
+                    "context_window": 131072,
+                    "max_output_tokens": 4096,
+                    "cost_per_million_tokens": 0.4
+                },
+                "coder": {
+                    "provider_identifier": "zai-org/GLM-5.1-FP8",
+                    "category": "smart",
+                    "context_window": 202752,
+                    "max_output_tokens": 4096,
+                    "cost_per_million_tokens": 0.85
+                },
+                "vision": {
+                    "provider_identifier": "Qwen/Qwen3-VL-30B-A3B-Instruct",
+                    "category": "balanced",
+                    "context_window": 256000,
+                    "max_output_tokens": 4096,
+                    "cost_per_million_tokens": 0.15
+                },
+                "opus": {
+                    "provider_identifier": "zai-org/GLM-5.1-FP8",
+                    "category": "smart",
+                    "context_window": 202752,
+                    "max_output_tokens": 4096,
+                    "cost_per_million_tokens": 0.85
+                },
+                "sonnet": {
+                    "provider_identifier": "Qwen/Qwen3.6-35B-A3B-FP8",
+                    "category": "balanced",
+                    "context_window": 262144,
+                    "max_output_tokens": 4096,
+                    "cost_per_million_tokens": 0.17
+                }
+            },
+            "features": {
+                "interactive": False,
+                "streaming": True,
+                "file_interception": False,
+                "session_persistence": False,
+                "code_execution": False,
+                "context_extension": False
+            },
+            "extra_params": {
+                "tee_inference": True
+            }
+        },
         "anthropic": {
             "type": "anthropic_api",
             "enabled": True,
@@ -387,7 +456,13 @@ class ProviderConfigManager:
                 continue
 
             # Validate API providers have required credentials
-            if config.type in ['venice_api', 'anthropic_api', 'openai_api']:
+            if config.type in [
+                'venice_api',
+                'nearai',
+                'nearai_api',
+                'anthropic_api',
+                'openai_api',
+            ]:
                 if not config.api_key and config.enabled:
                     import warnings
                     warnings.warn(
@@ -523,7 +598,13 @@ class ProviderConfigManager:
         for config in self._configs.values():
             if config.enabled:
                 # Skip API providers without keys
-                if config.type in ['venice_api', 'anthropic_api', 'openai_api']:
+                if config.type in [
+                    'venice_api',
+                    'nearai',
+                    'nearai_api',
+                    'anthropic_api',
+                    'openai_api',
+                ]:
                     if not config.api_key:
                         continue
                 return config

--- a/src/hydra/providers/provider_factory.py
+++ b/src/hydra/providers/provider_factory.py
@@ -223,6 +223,12 @@ class ProviderFactory:
             config.api_key = os.getenv("VENICE_API_KEY")
             config.base_url = os.getenv("VENICE_BASE_URL", "https://api.venice.ai/v1")
 
+        elif provider_type == "nearai" or provider_type == "nearai_api":
+            config.api_key = os.getenv("NEARAI_API_KEY")
+            config.base_url = os.getenv(
+                "NEARAI_BASE_URL", "https://cloud-api.near.ai/v1"
+            )
+
         elif "anthropic" in provider_type:
             config.api_key = os.getenv("ANTHROPIC_API_KEY")
             config.base_url = os.getenv("ANTHROPIC_BASE_URL", "https://api.anthropic.com")
@@ -271,6 +277,9 @@ class ProviderFactory:
         # Provider-specific overrides
         if config.type == "venice_api" and os.getenv("VENICE_API_KEY"):
             config.api_key = os.getenv("VENICE_API_KEY")
+
+        elif config.type in ["nearai", "nearai_api"] and os.getenv("NEARAI_API_KEY"):
+            config.api_key = os.getenv("NEARAI_API_KEY")
 
         elif "anthropic" in config.type and os.getenv("ANTHROPIC_API_KEY"):
             config.api_key = os.getenv("ANTHROPIC_API_KEY")

--- a/src/hydra/providers/provider_registry.py
+++ b/src/hydra/providers/provider_registry.py
@@ -48,6 +48,8 @@ class ProviderRegistry:
         ),
         "venice": "hydra.providers.venice.VeniceProvider",
         "venice_api": "hydra.providers.venice.VeniceProvider",  # Alias for compatibility
+        "nearai": "hydra.providers.nearai.NearAIProvider",
+        "nearai_api": "hydra.providers.nearai.NearAIProvider",
         "anthropic_api": "hydra.providers.anthropic.AnthropicProvider",
         "mock_provider": "hydra.providers.mock_provider.MockProvider",
         "mock": "hydra.providers.mock_provider.MockProvider",
@@ -153,7 +155,12 @@ class ProviderRegistry:
     def _register_lazy_init_callbacks(self) -> None:
         """Register lazy initialization callbacks for providers."""
         # Register callbacks for expensive providers
-        for provider_type in ["claude_tmux", "claude_cli_enhanced", "venice_api"]:
+        for provider_type in [
+            "claude_tmux",
+            "claude_cli_enhanced",
+            "venice_api",
+            "nearai",
+        ]:
             if provider_type in self._providers:
                 provider_class = self._providers[provider_type]
 
@@ -472,7 +479,13 @@ class ProviderRegistry:
 
         """
         # Check API-based providers
-        if config.type in ["venice_api", "anthropic_api", "openai"]:
+        if config.type in [
+            "venice_api",
+            "nearai",
+            "nearai_api",
+            "anthropic_api",
+            "openai",
+        ]:
             return bool(config.api_key)
 
         # Check CLI-based providers

--- a/src/hydra/providers/session_manager.py
+++ b/src/hydra/providers/session_manager.py
@@ -90,6 +90,10 @@ class SessionManager:
             api_key = os.getenv("VENICE_API_KEY")
             if api_key:
                 headers["Authorization"] = f"Bearer {api_key}"
+        elif provider in ["nearai", "nearai_api"]:
+            api_key = os.getenv("NEARAI_API_KEY")
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
 
         return headers
 

--- a/src/hydra/providers/venice.py
+++ b/src/hydra/providers/venice.py
@@ -706,7 +706,7 @@ class VeniceProvider(BaseProvider):
             logger.warning(f"Model {model_identifier} not in known models")
 
         self.config.model = model_identifier
-        logger.info(f"Selected Venice model: {model_identifier}")
+        logger.info(f"Selected {self.DISPLAY_NAME} model: {model_identifier}")
         return True
 
     def get_model_mapping(self) -> Dict[str, str]:
@@ -1191,22 +1191,22 @@ class VeniceProvider(BaseProvider):
             prompt = self._build_ticket_prompt(ticket_content)
 
             # Generate response from Venice
-            logger.info("Generating Venice response for ticket execution")
+            logger.info(f"Generating {self.DISPLAY_NAME} response for ticket execution")
             response = self.generate(prompt, **kwargs)
             execution_result["response"] = response
 
             # Parse response to extract actions
-            logger.info("Parsing Venice response for actions")
+            logger.info(f"Parsing {self.DISPLAY_NAME} response for actions")
             actions = self._parse_venice_response(response)
 
             if not actions:
-                logger.warning("No actions extracted from Venice response")
+                logger.warning(f"No actions extracted from {self.DISPLAY_NAME} response")
                 execution_result["errors"].append(
                     "No executable actions found in response"
                 )
                 return execution_result
 
-            logger.info(f"Extracted {len(actions)} actions from Venice response")
+            logger.info(f"Extracted {len(actions)} actions from {self.DISPLAY_NAME} response")
 
             # Create execution context
             context = ExecutionContext(
@@ -1348,7 +1348,7 @@ class VeniceProvider(BaseProvider):
             return actions
 
         except Exception as e:
-            logger.error(f"Failed to parse Venice response: {e}")
+            logger.error(f"Failed to parse {self.DISPLAY_NAME} response: {e}")
             # Try fallback parsing
             return self._fallback_parse_venice_response(response)
 
@@ -1381,7 +1381,7 @@ class VeniceProvider(BaseProvider):
                     content=content,
                     metadata={
                         "language": language,
-                        "source": "venice_parser",
+                        "source": f"{self.PROVIDER_SLUG}_parser",
                     }
                 )
                 actions.append(action)
@@ -1395,7 +1395,7 @@ class VeniceProvider(BaseProvider):
                         action = Action(
                             type=ActionType.RUN_COMMAND,
                             target=cmd,
-                            metadata={"source": "venice_parser"}
+                            metadata={"source": f"{self.PROVIDER_SLUG}_parser"}
                         )
                         actions.append(action)
 
@@ -1428,7 +1428,7 @@ class VeniceProvider(BaseProvider):
                     content=block.content,
                     metadata={
                         "language": block.language,
-                        "source": "venice_fallback",
+                        "source": f"{self.PROVIDER_SLUG}_fallback",
                     }
                 )
                 actions.append(action)
@@ -1440,7 +1440,7 @@ class VeniceProvider(BaseProvider):
                         action = Action(
                             type=ActionType.RUN_COMMAND,
                             target=line,
-                            metadata={"source": "venice_fallback"}
+                            metadata={"source": f"{self.PROVIDER_SLUG}_fallback"}
                         )
                         actions.append(action)
 
@@ -1528,7 +1528,7 @@ class VeniceProvider(BaseProvider):
 
         # Log final statistics
         logger.info(
-            f"Venice provider stats: requests={self.stats['total_requests']}, "
+            f"{self.DISPLAY_NAME} provider stats: requests={self.stats['total_requests']}, "
             f"successful={self.stats['successful_requests']}, "
             f"failed={self.stats['failed_requests']}, "
             f"retries={self.stats['retries']}"

--- a/src/hydra/providers/venice.py
+++ b/src/hydra/providers/venice.py
@@ -48,6 +48,11 @@ class VeniceProvider(BaseProvider):
 
     # Provider type identifier
     PROVIDER_TYPE = "venice_api"
+    PROVIDER_SLUG = "venice"
+    DISPLAY_NAME = "Venice AI"
+    API_KEY_ENV_VAR = "VENICE_API_KEY"
+    DEFAULT_BASE_URL = "https://api.venice.ai/api/v1"
+    DEFAULT_MODEL = "qwen-2.5-coder-32b"
 
     # Venice model mappings with coding-optimized models
     VENICE_MODELS = {
@@ -124,6 +129,7 @@ class VeniceProvider(BaseProvider):
             "cost_per_token": 0.0000001,
         },
     }
+    MODEL_CATALOG = VENICE_MODELS
 
     # Model name mappings for compatibility
     MODEL_MAPPINGS = {
@@ -141,18 +147,21 @@ class VeniceProvider(BaseProvider):
         """Validate Venice-specific configuration."""
         # Get API key from config or environment
         if not self.config.api_key:
-            self.config.api_key = os.getenv("VENICE_API_KEY")
+            self.config.api_key = os.getenv(self.API_KEY_ENV_VAR)
 
         if not self.config.api_key:
-            raise ValueError("Venice provider requires api_key (set VENICE_API_KEY)")
+            raise ValueError(
+                f"{self.DISPLAY_NAME} provider requires api_key "
+                f"(set {self.API_KEY_ENV_VAR})"
+            )
 
         # Set default Venice values
         if not self.config.base_url:
-            self.config.base_url = "https://api.venice.ai/api/v1"
+            self.config.base_url = self.DEFAULT_BASE_URL
 
         # Default to coding model if not specified
         if not self.config.model:
-            self.config.model = "qwen-2.5-coder-32b"
+            self.config.model = self.DEFAULT_MODEL
 
         # Map model name if needed
         self._resolve_model_name()
@@ -208,7 +217,10 @@ class VeniceProvider(BaseProvider):
             'total_tokens': 0
         }
 
-        logger.info(f"Venice provider initialized with model: {self.config.model}")
+        logger.info(
+            f"{self.DISPLAY_NAME} provider initialized with model: "
+            f"{self.config.model}"
+        )
 
     def _resolve_model_name(self) -> None:
         """Resolve model name using mappings."""
@@ -221,14 +233,14 @@ class VeniceProvider(BaseProvider):
 
     @property
     def name(self) -> str:
-        return "venice"
+        return self.PROVIDER_SLUG
 
     def generate(self, prompt: str, **kwargs) -> str:
         """Generate a response from Venice AI with retry logic and error handling."""
         self.stats['total_requests'] += 1
 
         # Check budget before making request
-        estimated_tokens = self.token_tracker.count_tokens(prompt, "venice") + 1000
+        estimated_tokens = self.token_tracker.count_tokens(prompt, self.name) + 1000
         budget_ok, message = self.token_tracker.check_budget_available(
             estimated_tokens, self.config.model
         )
@@ -289,12 +301,12 @@ class VeniceProvider(BaseProvider):
             output_tokens = usage_data.completion_tokens
         else:
             # Estimate if not provided
-            input_tokens = self.token_tracker.count_tokens(str(messages), "venice")
-            output_tokens = self.token_tracker.count_tokens(content, "venice")
+            input_tokens = self.token_tracker.count_tokens(str(messages), self.name)
+            output_tokens = self.token_tracker.count_tokens(content, self.name)
 
         # Track usage
         self.token_tracker.track_usage(
-            provider="venice",
+            provider=self.name,
             model=self.config.model,
             prompt=prompt,
             response=content,
@@ -561,7 +573,7 @@ class VeniceProvider(BaseProvider):
 
         except Exception as e:
             self.stats['failed_requests'] += 1
-            logger.error(f"Venice streaming error: {e}")
+            logger.error(f"{self.DISPLAY_NAME} streaming error: {e}")
             raise
         finally:
             # Restore original timeout
@@ -657,7 +669,7 @@ class VeniceProvider(BaseProvider):
         """
         models = []
 
-        for model_id, info in self.VENICE_MODELS.items():
+        for model_id, info in self.MODEL_CATALOG.items():
             models.append(ModelInfo(
                 identifier=model_id,
                 display_name=info["display_name"],
@@ -667,7 +679,10 @@ class VeniceProvider(BaseProvider):
                 supports_streaming=info["supports_streaming"],
                 supports_interactive=info["supports_interactive"],
                 cost_per_token=info.get("cost_per_token"),
-                metadata={"provider": "venice"}
+                metadata={
+                    "provider": self.name,
+                    **info.get("metadata", {}),
+                }
             ))
 
         return models
@@ -687,7 +702,7 @@ class VeniceProvider(BaseProvider):
             model_identifier = self.MODEL_MAPPINGS[model_identifier]
 
         # Check if model is available
-        if model_identifier not in self.VENICE_MODELS:
+        if model_identifier not in self.MODEL_CATALOG:
             logger.warning(f"Model {model_identifier} not in known models")
 
         self.config.model = model_identifier
@@ -719,7 +734,7 @@ class VeniceProvider(BaseProvider):
             text=response,
             code_blocks=code_blocks,
             metadata={
-                "provider": "venice",
+                "provider": self.name,
                 "model": self.config.model,
                 "timestamp": datetime.now().isoformat(),
                 "requires_code_extraction": len(code_blocks) > 0,
@@ -810,7 +825,7 @@ class VeniceProvider(BaseProvider):
         """
         session = Session(
             id=session_id,
-            provider="venice",
+            provider=self.name,
             model=self.config.model,
             created_at=datetime.now(),
             last_activity=datetime.now(),
@@ -967,12 +982,15 @@ class VeniceProvider(BaseProvider):
 
         if "api_key" in error_str.lower():
             return (
-                "Venice API key is invalid or not set. "
-                "Please check VENICE_API_KEY environment variable."
+                f"{self.DISPLAY_NAME} API key is invalid or not set. "
+                f"Please check {self.API_KEY_ENV_VAR} environment variable."
             )
 
         if "rate_limit" in error_str.lower():
-            return "Venice API rate limit exceeded. Please wait before retrying."
+            return (
+                f"{self.DISPLAY_NAME} API rate limit exceeded. "
+                "Please wait before retrying."
+            )
 
         if "model" in error_str.lower():
             return f"Model {self.config.model} not available. Please check model name."
@@ -1324,7 +1342,7 @@ class VeniceProvider(BaseProvider):
 
             # Enhance actions with Venice metadata
             for action in actions:
-                action.metadata["provider"] = "venice"
+                action.metadata["provider"] = self.name
                 action.metadata["model"] = self.config.model
 
             return actions
@@ -1518,7 +1536,7 @@ class VeniceProvider(BaseProvider):
 
         # Close HTTP session for this provider
         try:
-            self.session_manager.close_session("venice")
+            self.session_manager.close_session(self.name)
         except Exception as e:
             logger.debug(f"Failed to close session: {e}")
 

--- a/src/hydra/token_tracker.py
+++ b/src/hydra/token_tracker.py
@@ -35,6 +35,7 @@ class Provider(str, Enum):
     ANTHROPIC = "anthropic"
     OPENAI = "openai"
     VENICE = "venice"
+    NEARAI = "nearai"
     MOCK = "mock"
 
 
@@ -69,6 +70,25 @@ TOKEN_COSTS = {
     ),
     "gpt-3.5-turbo": TokenCost(
         Provider.OPENAI, "gpt-3.5-turbo", 0.0005, 0.0015, 16385, 4096
+    ),
+    "zai-org/GLM-5.1-FP8": TokenCost(
+        Provider.NEARAI, "zai-org/GLM-5.1-FP8", 0.00085, 0.0033, 202752, 4096
+    ),
+    "Qwen/Qwen3.6-35B-A3B-FP8": TokenCost(
+        Provider.NEARAI,
+        "Qwen/Qwen3.6-35B-A3B-FP8",
+        0.00017,
+        0.0011,
+        262144,
+        4096,
+    ),
+    "Qwen/Qwen3.5-122B-A10B": TokenCost(
+        Provider.NEARAI,
+        "Qwen/Qwen3.5-122B-A10B",
+        0.0004,
+        0.0032,
+        131072,
+        4096,
     ),
 }
 
@@ -179,6 +199,7 @@ class TokenTracker:
             # Claude uses cl100k_base encoding similar to GPT
             self._tokenizers["anthropic"] = tiktoken.get_encoding("cl100k_base")
             self._tokenizers["openai"] = tiktoken.get_encoding("cl100k_base")
+            self._tokenizers["nearai"] = tiktoken.get_encoding("cl100k_base")
             self._tokenizers["default"] = tiktoken.get_encoding("cl100k_base")
         except Exception as e:
             logger.warning(f"Failed to initialize tokenizers: {e}")
@@ -198,8 +219,9 @@ class TokenTracker:
         if not text:
             return 0
 
+        provider_value = provider.value if isinstance(provider, Provider) else str(provider)
         tokenizer = self._tokenizers.get(
-            provider.value, self._tokenizers.get("default")
+            provider_value, self._tokenizers.get("default")
         )
 
         if tokenizer:

--- a/tests/integration/test_nearai_provider.py
+++ b/tests/integration/test_nearai_provider.py
@@ -1,0 +1,108 @@
+"""Integration tests for the NEAR AI Cloud provider."""
+
+from unittest.mock import MagicMock, patch
+
+from hydra.providers.base import LLMConfig
+from hydra.providers.nearai import NearAIProvider
+from hydra.providers.output_handler import OutputHandlerFactory, VeniceOutputHandler
+from hydra.providers.provider_factory import ProviderFactory
+from hydra.providers.provider_registry import ProviderRegistry
+
+
+def create_nearai_provider(config: LLMConfig) -> NearAIProvider:
+    """Create a NEAR AI provider with OpenAI clients patched."""
+    with (
+        patch("hydra.providers.venice.OpenAI"),
+        patch("hydra.providers.venice.AsyncOpenAI"),
+        patch("hydra.providers.venice.get_session_manager", return_value=MagicMock()),
+        patch("hydra.providers.venice.get_token_tracker", return_value=MagicMock()),
+    ):
+        return NearAIProvider(config)
+
+
+class TestNearAIProviderIntegration:
+    """Test NEAR AI Cloud provider integration."""
+
+    def test_nearai_provider_initialization_defaults(self):
+        """Test NEAR AI provider initializes with expected defaults."""
+        config = LLMConfig(provider_type="nearai", api_key="test-key")
+
+        provider = create_nearai_provider(config)
+
+        assert provider.name == "nearai"
+        assert provider.config.base_url == "https://cloud-api.near.ai/v1"
+        assert provider.config.model == "zai-org/GLM-5.1-FP8"
+
+    def test_nearai_model_mapping_and_metadata(self):
+        """Test NEAR AI model mappings and TEE metadata."""
+        config = LLMConfig(provider_type="nearai", api_key="test-key")
+        provider = create_nearai_provider(config)
+
+        mapping = provider.get_model_mapping()
+        assert mapping["fast"] == "Qwen/Qwen3.6-35B-A3B-FP8"
+        assert mapping["balanced"] == "zai-org/GLM-5.1-FP8"
+        assert mapping["smart"] == "Qwen/Qwen3.5-122B-A10B"
+
+        models = provider.list_models()
+        assert any(model.identifier == "zai-org/GLM-5.1-FP8" for model in models)
+        assert all(model.metadata["provider"] == "nearai" for model in models)
+        assert all(model.metadata["tee_inference"] is True for model in models)
+
+    def test_nearai_selects_generic_model(self):
+        """Test selecting a generic model alias."""
+        config = LLMConfig(provider_type="nearai", api_key="test-key")
+        provider = create_nearai_provider(config)
+
+        assert provider.select_model("fast") is True
+        assert provider.config.model == "Qwen/Qwen3.6-35B-A3B-FP8"
+
+    def test_nearai_registered_in_provider_registry(self):
+        """Test registry can create the NEAR AI provider."""
+        registry = ProviderRegistry()
+        config = LLMConfig(provider_type="nearai", api_key="test-key")
+
+        with (
+            patch("hydra.providers.venice.OpenAI"),
+            patch("hydra.providers.venice.AsyncOpenAI"),
+            patch(
+                "hydra.providers.venice.get_session_manager",
+                return_value=MagicMock(),
+            ),
+            patch("hydra.providers.venice.get_token_tracker", return_value=MagicMock()),
+        ):
+            provider = registry.create_provider("nearai", config)
+
+        assert isinstance(provider, NearAIProvider)
+        assert provider.name == "nearai"
+
+    def test_nearai_factory_environment_config(self):
+        """Test factory environment handling for NEAR AI."""
+        factory = ProviderFactory()
+
+        with (
+            patch.dict(
+                "os.environ",
+                {"LLM_PROVIDER": "nearai", "NEARAI_API_KEY": "test-key"},
+                clear=True,
+            ),
+            patch("hydra.providers.venice.OpenAI"),
+            patch("hydra.providers.venice.AsyncOpenAI"),
+            patch(
+                "hydra.providers.venice.get_session_manager",
+                return_value=MagicMock(),
+            ),
+            patch("hydra.providers.venice.get_token_tracker", return_value=MagicMock()),
+        ):
+            provider = factory.from_environment()
+
+        assert isinstance(provider, NearAIProvider)
+        assert provider.config.api_key == "test-key"
+
+    def test_nearai_uses_openai_compatible_output_handler(self):
+        """Test NEAR AI output handling uses the OpenAI-compatible parser."""
+        handler = OutputHandlerFactory.create("nearai")
+        parsed = handler.parse("```python\nprint('ok')\n```")
+
+        assert isinstance(handler, VeniceOutputHandler)
+        assert parsed.metadata["provider"] == "nearai"
+        assert parsed.metadata["requires_code_extraction"] is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -94,6 +94,9 @@ class TestCLIParser:
         # Test provider flag
         args = parser.parse_args(['--provider', 'venice', 'template', 'list'])
         assert args.provider == 'venice'
+
+        args = parser.parse_args(['--provider', 'nearai', 'template', 'list'])
+        assert args.provider == 'nearai'
         
         # Test model flag
         args = parser.parse_args(['--model', 'gpt-4', 'template', 'list'])


### PR DESCRIPTION
## Summary
- Adds NEAR AI Cloud (`nearai`) as an OpenAI-compatible TEE inference provider.
- Registers NEAR AI Cloud across provider discovery, configuration, env handling, token tracking, batching, and output handling.
- Documents setup with `NEARAI_API_KEY` / `NEARAI_BASE_URL` and adds focused provider tests.

## Implementation Notes
- Reuses the existing OpenAI-compatible provider behavior through provider-specific metadata and defaults.
- Defaults to `https://cloud-api.near.ai/v1` and `zai-org/GLM-5.1-FP8`.
- Includes a small static TEE model snapshot generated from the public NEAR AI Cloud model catalog on 2026-05-21.

## Testing
- `python -m py_compile src/hydra/providers/nearai.py src/hydra/providers/venice.py src/hydra/providers/factory.py src/hydra/providers/provider_registry.py src/hydra/providers/provider_factory.py src/hydra/providers/provider_config.py src/hydra/providers/session_manager.py src/hydra/providers/output_handler.py src/hydra/performance.py src/hydra/performance_optimizations.py src/hydra/token_tracker.py src/hydra/config.py src/hydra/cli/main.py tests/integration/test_nearai_provider.py tests/test_cli.py`
- `pytest tests/integration/test_nearai_provider.py tests/test_cli.py::TestCLIParser::test_global_flags -q`

Live API smoke testing was not run because no `NEARAI_API_KEY` was available in the test environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NEAR AI Cloud provider support with API-key authentication and configurable base URL; LLM_PROVIDER default updated to nearai
  * New environment variables: NEARAI_API_KEY and NEARAI_BASE_URL; CLI/provider selection now includes nearai

* **Documentation**
  * Added NEAR AI Cloud setup guide and updated README, API reference, architecture, and examples to reflect nearai support

* **Tests**
  * Added integration tests covering NEAR AI provider setup and behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->